### PR TITLE
Adopt a new way to go with the loglevels

### DIFF
--- a/C/Android.mk
+++ b/C/Android.mk
@@ -1,2 +1,12 @@
 LOCAL_PATH := $(call my-dir)
+ifeq ($(LOG_WRAP_TAGS),true)
+	LOCAL_CFLAGS += -DLOG_WRAP_TAGS
+endif
+
+ifeq ($(DEFAULT_LOG_LOC),)
+	LOCAL_CFLAGS += -DDEFAULT_LOG_LOC=\"$(DEFAULT_LOG_LOC)\"
+endif
+ifeq ($(ALT_LOG_LOC),)
+	LOCAL_CFLAGS += -DALT_LOG_LOC=\"$(ALT_LOG_LOC)\"
+endif
 LOCAL_SRC_FILES := kmsg_log.c

--- a/C/kmsg_log.c
+++ b/C/kmsg_log.c
@@ -1,82 +1,97 @@
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 
-#ifndef LOG_LOC
- #define LOG_LOC "/cache/lible.log"
+#ifndef ALT_LOG_LOC
+ #define ALT_LOG_LOC "/cache/lible.log"
 #endif
 
+#ifndef DEFAULT_LOG_LOC
+  #define  DEFAULT_LOG_LOC "/dev/kmsg"
+#endif
 
-int klog(char *msg)
+/*
+  This is the main function "klog"
+  it takes the the log level
+  ======================================\
+   label  | loglevel | message          /
+  ======================================\
+  | Info  | 0        |  Info :    || I: /
+  | Warn  | 1        |  Warn :    || W: \
+  | Error | 2        |  Error :   || E: /
+  | Debug | 3        |  Debug :   || D: \
+  ===================================== /
+  then opens the /dev/kmsg or DEFAULT_LOG_LOC (if defined) ,
+  if it cant acces the location ,
+  it tries to open the ALT_LOG_LOC ,
+  and writes "COULD NOT OPEN KMSG PLEASE FIX".
+*/
+int klog(int level, char *msg)
 {
 
- char *buf = malloc(sizeof(char) * 256);
- int ret = -1; 
+ int ret = -1;
+ char buf [256];
 
-  // Write to kmsg if possibe.
- int outbuf = open("/dev/kmsg", O_WRONLY);
-  if (outbuf > 0) // Trying to open KMSG, 
-  {
-    strcpy(buf,*msg);    
-  } else { //If kmesg don't open write to sd
-    /*
-      Now if the file doesn't exists, we would open another file on the sdcard to transmit our KMSG.
-    */
-    if (access(LOG_LOC, F_OK ) == -1) {  // Check if the file exists.
-      outbuf = open(LOG_LOC, O_CREAT | O_WRONLY); // If it doesn't exist, create it and open it to write to it.
-
-    } else {
+ int outbuf = open(DEFAULT_LOG_LOC, O_WRONLY);
+  if (outbuf > 0) // [1] Open the DEFAULT_LOG_LOC
+      ;
+   else { // IF we cant open the DEFAULT_LOG_LOC
+    if (access(ALT_LOG_LOC, F_OK ) == -1) { //Check for ALT_LOG_LOC
+      outbuf = open(ALT_LOG_LOC, O_CREAT | O_WRONLY); //IF not create one and open it for reading
+    } else { // if ALT_LOG_LOC exists then open it to O_APPEND
 		/*
 		* TODO: Make better file checks.
 		*/
-	  outbuf = open(LOG_LOC, O_APPEND); // Else, assume file already exist: Open to append. 
-	}
-
-    /*
-      Checking is done, now we will write to the KMSG.
-    */
-
+	  outbuf = open(ALT_LOG_LOC, O_APPEND);
       strcpy(buf,"COULD NOT OPEN KMSG PLEASE FIX");
-
     }
+  }
+  switch (level)
+   {
+    case 0 :
+            #ifdef LOG_WRAP_TAGS
+                strcpy(buf,"I:");
+                strcat(buf,msg);
+            #else
+                strcpy(buf,"Info :");
+                strcat(buf,msg);
+            #endif
 
-	ret = write(outbuf, buf, strlen(buf) ); // Write "Test" to KMSG
+    case 1 :
+            #ifdef LOG_WRAP_TAGS
+                strcpy(buf,"W:");
+                strcat(buf,msg);
+            #else
+                strcpy(buf,"Warn :");
+                strcat(buf,msg);
+            #endif
 
-	close(outbuf); // CLOSE THE FILE DISCRIPTOR TO AVOID LEAK ;
+    case 2 :
+            #ifdef LOG_WRAP_TAGS
+                strcpy(buf,"E:");
+                strcat(buf,msg);
+            #else
+                strcpy(buf,"Error:");
+                strcat(buf,msg);
+            #endif
 
-	free(buf); // Empty buf memory.
+    case 3 :
+            #ifdef LOG_WRAP_TAGS
+                strcpy(buf,"D:");
+                strcat(buf,msg);
+            #else
+                strcpy(buf,"Debug:");
+                strcat(buf,msg);
+            #endif
+            break ;
+    default : strcpy(buf,"Error : Unknown log level ");
+              break;
+          }
+	ret = write(outbuf, buf, strlen(buf) );
+	close(outbuf);
+
 	return ret;
 }
-
-	int logwarn(char *warning) 
-	{ 
-		char *warn ="Warning! : "  ;
-		strcat(*warn,*warning);
-		int ret = klog(*warn);
-		return(ret);
-	}	
-
-	int logerror(char *error) 
-	{ 
-		char *error_tag ="Error! : "  ;
-		strcat(*error_tag,error);
-		int ret = klog(*error_tag);
-		return(ret);
-	}	
-	int logdebug (char *debug_msg)
-	{
-		char *debug_tag = "Debug : ";
-		strcat(*debug_tag,debug_msg);
-		int ret = klog(*debug_tag);
-		return(ret);
-	}
-	int loginfo (char *info)
-	{
-		char *info_tag = "Info : ";
-		strcat(*info_tag,info);
-		int ret = klog(*info_tag);
-		return(ret);
-	}


### PR DESCRIPTION
        Now users can add "DEFAULT_LOG_LOC" to their Makefile to change the default logging location , in a similar way they can change the "ALT_LOG_LOC" to change the alternative  location ( the location lib-le-log falls to if DEFAULT_LOG_LOC fails).

        Now the previous functions of warn/error/info/debug are removed. The parent function has to a pass a "loglevel"
 ======================= \
   label  | loglevel | message     /
 ======================== \
  | Info      | 0        |  Info :           /
  | Warn    | 1        |  Warn :         \
  | Error    | 2        |  Error :        /
  | Debug  | 3        |  Debug :      \
  ======================== /

so now a function looks like `klog(0,"This was a test message");`
and the output `Info : This was a a test message`

We have also added flag `LOG_WRAP_TAGS`. This flag allows the user to wrap the log tags 
so , 
Info = I: 
Warn = W:
Error = E:
Debug = D: 

This allows to user to maximize the output that can be given  (max is 256 chars).

We have also started to use stack based allocations rather than heap based. 

Lots of rudimentary comments have been removed. Every function should have only one comment which briefs the work done by it, rest should be explained  by the code itself. But all the comments have not been removed , some exist ( but changed ) . They exists to explain the file opening sequence. 

The header <unistd.h> has been moved upwards, because it defines the POSIX_VERSION which is used in many other headers